### PR TITLE
Feature: use gon object to show spantree

### DIFF
--- a/content/src/scripts/containers/app/App.css
+++ b/content/src/scripts/containers/app/App.css
@@ -1,0 +1,3 @@
+.nav-sidebar {
+  transition: width 0.3s !important;
+}

--- a/content/src/scripts/index.js
+++ b/content/src/scripts/index.js
@@ -11,16 +11,13 @@ const proxyStore = new Store();
 const anchor = document.createElement("div");
 anchor.id = "rcr-anchor";
 
-if (document.querySelectorAll('[aria-label="Loading"]').length === 0) {
-  mount();
-} else {
-  let intervalId = null;
-  intervalId = setInterval(() => {
-    if (document.querySelectorAll('[aria-label="Loading"]').length === 0) {
-      clearInterval(intervalId);
-      mount();
-    }
-  }, 500);
+const isGitlabPage = function() {
+  const headList = Array.from(document.head.querySelectorAll('script'));
+  const gonEl = headList.find(item => item.innerHTML.includes('gon.gitlab_url'));
+  if (gonEl) {
+    return true;
+  }
+  return document.querySelectorAll('[aria-label="Loading"]').length === 0;
 }
 
 const mount = () => {
@@ -43,5 +40,17 @@ const mount = () => {
     });
   }
 };
+
+if (isGitlabPage()) {
+  mount();
+} else {
+  let intervalId = null;
+  intervalId = setInterval(() => {
+    if (isGitlabPage()) {
+      clearInterval(intervalId);
+      mount();
+    }
+  }, 500);
+}
 
 export default proxyStore;


### PR DESCRIPTION
Although there is no `gon` object on the obtained `window` object

but the `gon` content text information can be obtained through `document.innerHTML`

so that it can be judged whether it is a **gitlab page**.


---------------

By the way, some of the methods for obtaining `gon` object judgment mentioned in issues can also be obtained using the `document.innerHTML` +  `regular` expression method.
